### PR TITLE
Issue: 15. 

### DIFF
--- a/src/modules/dictionary.js
+++ b/src/modules/dictionary.js
@@ -1,46 +1,34 @@
-/**
- * This dictionary module loads a words list and exports
- * a single funtion to check if a given word is in that list.
- * 
- * That function returns true if the word is in the dictionary
- * and false if it does not.
- * 
- * The search is CASE SENSITIVE
- */
-
 import words from "./words.js";
 
 function binarySearch(needle, haystack){
-    let start = 0;
-    let end = haystack.length;
-    while ( start < end ){
+   
+    let currentArrayEndPoint = haystack.length;
+    let currentArrayStartPoint = 0;
+    let currentArrayLength = currentArrayEndPoint - currentArrayStartPoint;
+    let middleWord = Math.round((currentArrayEndPoint + currentArrayStartPoint) / 2);
 
-        //Find the half way point
-        let middle = Math.floor((start + end) / 2);
+    while(currentArrayLength > 1){
+    
 
-        //Find the word at the half way point
-        let middleWord = haystack[middle];
-
-        //We can log our progress if we want
-        //console.log(start, end, pivot, wordAtPivot);
-
-        //Check if we found the word
-        if ( middleWord == needle){
-            //We found it!
+        if(needle == (haystack[middleWord])){
             return true;
+        } else if(needle > haystack[middleWord]){
+            currentArrayStartPoint = middleWord + 1;
+            middleWord = Math.round((currentArrayEndPoint + currentArrayStartPoint) / 2);
+        } else if(needle < haystack[middleWord]){
+            currentArrayEndPoint = middleWord - 1;
+            middleWord = Math.round((currentArrayEndPoint + currentArrayStartPoint) / 2);
         }
-        
-        if ( middleWord < needle ){
-            //The needle comes AFTER the middle, so
-            //search between middle and end.
-            start = middle + 1;
-        } else if ( middleWord > needle ){
-            //The needle comes BEFORE the middle word,
-            // so search between start and middle
-            end = middle;
-        }
+    currentArrayLength = currentArrayEndPoint - currentArrayStartPoint;
     }
+
+    if(needle == haystack[currentArrayEndPoint] || needle == haystack[currentArrayStartPoint]) {
+        return true;
+    } else {
+
     return false;
+
+    }
 }
 
 export default function(word){

--- a/src/modules/personal-dictionary.js
+++ b/src/modules/personal-dictionary.js
@@ -1,26 +1,16 @@
-/**
- * This module defines a personal dictionary. It exports
- * a search function, and an addWord function that may be
- * used to add a word.
- * 
- * It is initially empty.
- * Search is case sensitive.
- */
-
-//An array of words, initially empty
 let words = [];
 
-//This function searches the words array for the word
-//parameter and returns true if it is found, false
-//otherwise
-function search(word){
-    return words.includes(word);
+export function search(word){
+    for(let i = 0; i < words.length; i++){
+        if(word == words[i]){
+            return true;
+        }
+    }
+
+    return false;
 }
 
-//This function adds the provided word to the words
-//array
-function addWord(word){
+export function addWord(word){
     words.push(word);
-}
 
-export {search, addWord};
+}

--- a/src/modules/spell-checker.js
+++ b/src/modules/spell-checker.js
@@ -29,9 +29,9 @@ function isWord(aString){
 function isSpelledRight(word){
     if ( !isWord(word) )
         return true;
-    else if ( checkDictionary(word.toLowerCase()) )
+    else if ( checkPersonalDictionary(word) )
         return true;
-    else if ( checkPersonalDictionary(word.toLowerCase()) )
+    else if (checkDictionary(word.toLowerCase()) || checkDictionary(word))
         return true;
     else
         return false;

--- a/test/spell-checker-tests.js
+++ b/test/spell-checker-tests.js
@@ -31,6 +31,14 @@ describe("SpellCheck tests", function () {
             assert.ok(!isSpelledRight("Pikachu"));
         });
 
+        it("Reports that Texas is spelled right", function () {
+            assert.ok(isSpelledRight("Texas"));
+        });
+
+        it("Reports that texas is misspelled", function () {
+            assert.ok(!isSpelledRight("texas"));
+        });
+
     });
 
     describe("Spell Check add words Tests", function () {
@@ -38,6 +46,38 @@ describe("SpellCheck tests", function () {
             assert.ok(!isSpelledRight("samsquanch")); //Does not find the word
             addWord("samsquanch");
             assert.ok(isSpelledRight("samsquanch")); //Does find the word
+        });
+    });
+
+    describe("Spell Check add words Tests", function () {
+        it("Finds the word Juan after adding it", function () {
+            assert.ok(!isSpelledRight("Juan")); //Does not find the word
+            addWord("Juan");
+            assert.ok(isSpelledRight("Juan")); //Does find the word
+        });
+    });
+
+    describe("Test addWord function", function () {
+        it("Finds the word juan after adding it", function () {
+            assert.ok(!isSpelledRight("juan")); //Does not find the word
+            addWord("juan");
+            assert.ok(isSpelledRight("juan")); //Does find the word
+        });
+    });
+
+    describe("Test addWord function", function () {
+        it("Finds the word creet after adding it", function () {
+            assert.ok(!isSpelledRight("creet")); //Does not find the word
+            addWord("creet");
+            assert.ok(isSpelledRight("creet")); //Does find the word
+        });
+    });
+
+    describe("Test addWord function", function () {
+        it("Finds the word Dame after adding it", function () {
+            assert.ok(!isSpelledRight("Dame")); //Does not find the word
+            addWord("Dame");
+            assert.ok(isSpelledRight("Dame")); //Does find the word
         });
     });
 


### PR DESCRIPTION
Test testing addition of capitalized word to personal dictionary fails. Edition of code has not solved the problem. Capitalized words such as "Texas" in the general dictionary, which were flagged as misspelled before, now are correct.