### PR TITLE
Capitals and Proper Nouns in the Software #7

### DIFF
--- a/src/modules/personal-dictionary.js
+++ b/src/modules/personal-dictionary.js
@@ -13,8 +13,16 @@ let words = [];
 //This function searches the words array for the word
 //parameter and returns true if it is found, false
 //otherwise
-function search(word){
-    return words.includes(word);
+function search(needle, haystack){    
+    let start = 0; 
+    let end = haystack.length; 
+    
+    for (let i = start; i < end; i++) {
+        if (needle == haystack[i]) {
+            return true;
+        }
+    }
+    return false;
 }
 
 //This function adds the provided word to the words

--- a/src/modules/personal-dictionary.js
+++ b/src/modules/personal-dictionary.js
@@ -13,12 +13,12 @@ let words = [];
 //This function searches the words array for the word
 //parameter and returns true if it is found, false
 //otherwise
-function search(needle, haystack){    
+function search(needle){    
     let start = 0; 
-    let end = haystack.length; 
+    let end = words.length; 
     
     for (let i = start; i < end; i++) {
-        if (needle == haystack[i]) {
+        if (needle == words[i]) {
             return true;
         }
     }

--- a/src/modules/personal-dictionary.js
+++ b/src/modules/personal-dictionary.js
@@ -6,7 +6,7 @@
  * It is initially empty.
  * Search is case sensitive.
  */
-
+//making a note so i can commit and push
 //An array of words, initially empty
 let words = [];
 

--- a/test/spell-checker-tests.js
+++ b/test/spell-checker-tests.js
@@ -2,7 +2,7 @@ import { splitIntoWords, isSpelledRight, addWord } from "../src/modules/spell-ch
 import assert from "assert"; //Utilities to help the test
 
 
-//These tests us a framework named Mocha https://mochajs.org/#getting-started
+//These tests use a framework named Mocha https://mochajs.org/#getting-started
 // "describe" and "it" are part of the mocha framework.
 
 describe("SpellCheck tests", function () {
@@ -49,6 +49,11 @@ describe("Spell Check add words Tests", function () {
         addWord("Reilly");
         assert.ok(isSpelledRight("Reilly")); //Does find the word
     });
+
+    it("Reports that Texas is spelled right", function () {
+        assert.ok(isSpelledRight("Texas"));
+    });
+
 });
 
 

--- a/test/spell-checker-tests.js
+++ b/test/spell-checker-tests.js
@@ -42,3 +42,13 @@ describe("SpellCheck tests", function () {
     });
 
 });
+
+describe("Spell Check add words Tests", function () {
+    it("Finds the word Reilly after adding it", function () {
+        assert.ok(!isSpelledRight("Reilly")); //Does not find the word
+        addWord("Reilly");
+        assert.ok(isSpelledRight("Reilly")); //Does find the word
+    });
+});
+
+


### PR DESCRIPTION
Here's the functions that I've used that should make everything work but it's not. Words like Texas and Reilly are being marked misspelled when they're not.

describe("Spell Check add words Tests", function () {
    it("Finds the word Reilly after adding it", function () {
        assert.ok(!isSpelledRight("Reilly")); //Does not find the word
        addWord("Reilly");
        assert.ok(isSpelledRight("Reilly")); //Does find the word
    });

    it("Reports that Texas is spelled right", function () {
        assert.ok(isSpelledRight("Texas"));
    });

});